### PR TITLE
Replace deprecated dot-dot notation in ggplot2

### DIFF
--- a/R/asvhist.R
+++ b/R/asvhist.R
@@ -31,7 +31,7 @@ asvhist <- function(x, scale = "log", type = "freq", nbins = "FD",
                     xlim = NULL, ylim = NULL, color = "black", fill = "grey") {
   if (!is.vector(x) || any(x <= 0))
     stop("use only with a vector of count data (all positive integers)")
-  count <- ..density.. <- NULL
+  count <- density <- NULL
   if (scale == "log") {
     x <- log10(x)
   }
@@ -65,7 +65,7 @@ asvhist <- function(x, scale = "log", type = "freq", nbins = "FD",
   }
   if (type == "density") {
     h <- h +
-      geom_histogram(aes(y = ..density..),
+      geom_histogram(aes(y = after_stat(density)),
                      bins = nb, breaks = brk, color = color, fill = fill) +
       scale_y_continuous(limits = ylim, expand = c(0, 0)) +
       ylab("Density")

--- a/R/autoplot.gmmem.R
+++ b/R/autoplot.gmmem.R
@@ -52,7 +52,7 @@ autoplot.gmmem <- function(object, scale = "log", type = "freq", nbins = "FD",
                            dist.alpha = NULL, vline.color = NULL, ...) {
   if (!inherits(object, "gmmem"))
     stop("The object needs to be a \'gmmem\'-class")
-  x <- density <- comp <- ..count.. <- ..density.. <- NULL
+  x <- density <- comp <- count <- density <- NULL
   # Set bin number or bin break points
   raw.x <- object$x
   if (is.null(nbins) || is.numeric(nbins)) {
@@ -93,7 +93,7 @@ autoplot.gmmem <- function(object, scale = "log", type = "freq", nbins = "FD",
     n <- length(raw.x)
     p <- ggplot() +
       geom_histogram(data = hist.df,
-                     mapping = aes(x = raw.x, y = ..count..),
+                     mapping = aes(x = raw.x, y = after_stat(count)),
                      bins = nb, breaks = brk,
                      color = hist.color, fill = hist.fill) +
       geom_line(data = density.df,
@@ -120,7 +120,7 @@ autoplot.gmmem <- function(object, scale = "log", type = "freq", nbins = "FD",
     density.df <- predict.gmmem(object, newdata = new.x)
     p <- ggplot() +
       geom_histogram(data = hist.df,
-                     mapping = aes(x = raw.x, y = ..density..),
+                     mapping = aes(x = raw.x, y = after_stat(density)),
                      bins = nb, breaks = brk,
                      color = hist.color, fill = hist.fill) +
       geom_line(data = density.df, mapping = aes(x = x, y = density, color = comp),


### PR DESCRIPTION
Replaced the deprecated dot-dot notation( `..count..` and `..density..`) in ggplot2.